### PR TITLE
feat!: rely on CSS `:has` not JS `.has-list`

### DIFF
--- a/tacc_readthedocs/css/tacc-theme/tacc-docs.css
+++ b/tacc_readthedocs/css/tacc-theme/tacc-docs.css
@@ -133,7 +133,7 @@
     padding: var(--link-pad-vert) var(--link-pad-horz); /* overwrite theme.css */
   }
   .wy-menu-vertical li.on ul,
-  .wy-menu-vertical li.current.has-list ul {
+  .wy-menu-vertical li.current ul {
     padding-left: var(--link-pad-horz);
     padding-bottom: 10px;
   }
@@ -159,11 +159,11 @@
   .wy-menu-vertical li a {
     position: relative; /* support `position: absolute` child */
   }
-  .wy-menu-vertical li:not(.has-list) a button.toctree-expand {
+  .wy-menu-vertical li:not(:has(ul)) a button.toctree-expand {
     display: none;
   }
   .wy-menu-vertical li a .fa,
-  .wy-menu-vertical li.has-list a button.toctree-expand {
+  .wy-menu-vertical li:has(ul) a button.toctree-expand {
     margin-left: unset; /* undo theme.css */
 
     position: absolute;
@@ -177,7 +177,7 @@
     width: var(--button-width);
     text-align: center;
   }
-  .wy-menu-vertical li.has-list a,
+  .wy-menu-vertical li:has(ul) a,
   .wy-menu-vertical li a:not(.internal) {
     padding-left: var(--button-space);
   }

--- a/tacc_readthedocs/js/tacc-theme/modules/changeNavMarkup.js
+++ b/tacc_readthedocs/js/tacc-theme/modules/changeNavMarkup.js
@@ -1,11 +1,5 @@
 /* FAQ: jQuery element selector is used cuz Firefox does not support :has() */
 
-/* To add class for nav items that have sub-navs */
-$('.wy-menu-vertical li:has(li)').each(function() {
-
-  this.classList.add('has-list');
-});
-
 /* To add icon to nav items that are external links */
 document.querySelectorAll(`
   .wy-menu-vertical a:not(.internal),


### PR DESCRIPTION
## Overview

Rely only on CSS, not JavaScript, for selectors to style nested nav.

## Testing

Nested navigation looks like it did with or without JavaScript.

## Notes

> [!NOTE]
> Safari 15.3– might render less-than-ideal nav UI, because of browser support for `>has()](https://developer.mozilla.org/en-US/docs/Web/CSS/:has#browser_compatibility), but we only [support latest browser technology -2 major versions](https://brand.utexas.edu/application/web-guidelines/).
