### PR TITLE
refactor!: js - integrate into theme, reorg

### DIFF
--- a/docs/clients/basic-example.md
+++ b/docs/clients/basic-example.md
@@ -20,7 +20,6 @@ theme:
 
 ```yaml
 extra_css:
-  - css/tacc-theme.css # to retain TACC theme UI
   - css/specific-to-your-project.css
 ```
 
@@ -28,6 +27,5 @@ extra_css:
 
 ```yaml
 extra_javascript:
-  - js/tacc-theme.mjs # to retain TACC theme UX
   - js/specific-to-your-project.js
 ```

--- a/docs/clients/ds-user-guide-example.md
+++ b/docs/clients/ds-user-guide-example.md
@@ -24,7 +24,6 @@ theme:
 
 ```yaml
 extra_css:
-  - css/tacc-theme.css # to retain TACC theme UI
   - css/ds-docs.css
 ```
 
@@ -32,10 +31,13 @@ extra_css:
 
 ```yaml
 extra_javascript:
-  - js/tacc-theme.mjs # to retain TACC theme UX
   - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js
 ```
+
+/// tip |
+Try Markdown Extension `pymdownx.arithmatex` instead of `mathjax` to render LaTeX math equations.
+///
 
 ## Unique Markdown Extensions
 
@@ -44,3 +46,7 @@ markdown_extensions:
   - pymdownx.arithmatex:
       generic: true
 ```
+
+/// warning |
+Untested.
+///

--- a/docs/clients/tacc-docs-example.md
+++ b/docs/clients/tacc-docs-example.md
@@ -1,6 +1,6 @@
 # How to Configure "TACC Docs"
 
-How [TACC/TACC-Docs][tacc-docs] project should use this theme.
+How [TACC/TACC-Docs][tacc-docs]{target="_blank"} project should use this theme.
 
 [tacc-docs]: https://github.com/TACC/TACC-Docs
 

--- a/docs/clients/tacc-docs-example.md
+++ b/docs/clients/tacc-docs-example.md
@@ -1,6 +1,6 @@
 # How to Configure "TACC Docs"
 
-How [TACC/TACC-Docs][tacc-docs]{target="_blank"} project should use this theme.
+How [TACC/TACC-Docs][tacc-docs] project should use this theme.
 
 [tacc-docs]: https://github.com/TACC/TACC-Docs
 

--- a/docs/clients/tacc-docs-example.md
+++ b/docs/clients/tacc-docs-example.md
@@ -29,7 +29,6 @@ theme:
 
 ```yaml
 extra_css:
-  - css/tacc-theme.css # to retain TACC theme UI
   - css/specific-to-tacc-docs.css
 ```
 
@@ -37,6 +36,5 @@ extra_css:
 
 ```yaml
 extra_javascript:
-  - js/tacc-theme.mjs # to retain TACC theme UX
   - js/specific-to-tacc-docs.js
 ```

--- a/docs/customize.md
+++ b/docs/customize.md
@@ -12,7 +12,6 @@ Add your own CSS files to override the theme's default styles:
 
 ```yaml
 extra_css:
-    - css/tacc-theme.css # load this first to retain TACC theme UI
     - css/custom.css
 ```
 
@@ -22,7 +21,6 @@ Add your own JavaScript files to extend the theme's functionality:
 
 ```yaml
 extra_javascript:
-    - js/tacc-theme.mjs # load this first to retain TACC theme UX
     - js/custom.js
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,8 +15,6 @@ theme:
   # "TACC" Theme Features
   cms_url: https://github.com/TACC/Core-Docs
   cms_name: TACC/Core-Docs
-extra_javascript:
-  - js/tacc-theme.mjs
 
 nav:
   - Getting Started:

--- a/tacc_readthedocs/css/tacc-theme/readthedocs-reskin.css
+++ b/tacc_readthedocs/css/tacc-theme/readthedocs-reskin.css
@@ -109,7 +109,7 @@ svg.logo [fill]:not([fill="none"]) {
   padding: var(--link-pad-vert) var(--link-pad-horz); /* overwrite theme.css */
 }
 .wy-menu-vertical li.on ul,
-.wy-menu-vertical li.current ul {
+.wy-menu-vertical li.current:has(li) ul {
   padding-left: var(--link-pad-horz);
   padding-bottom: 10px;
 }
@@ -134,11 +134,11 @@ svg.logo [fill]:not([fill="none"]) {
 .wy-menu-vertical li a {
   position: relative; /* support `position: absolute` child */
 }
-.wy-menu-vertical li:not(:has(ul)) a button.toctree-expand {
+.wy-menu-vertical li:not(:has(li)) a button.toctree-expand {
   display: none;
 }
 .wy-menu-vertical li a .fa,
-.wy-menu-vertical li:has(ul) a button.toctree-expand {
+.wy-menu-vertical li:has(li) a button.toctree-expand {
   margin-left: unset; /* to undo theme.css */
 
   position: absolute;
@@ -152,7 +152,7 @@ svg.logo [fill]:not([fill="none"]) {
   width: var(--button-width);
   text-align: center;
 }
-.wy-menu-vertical li:has(ul) a,
+.wy-menu-vertical li:has(li) a,
 .wy-menu-vertical li a:not(.internal) {
   padding-left: var(--button-space);
 }

--- a/tacc_readthedocs/js/tacc-theme.mjs
+++ b/tacc_readthedocs/js/tacc-theme.mjs
@@ -1,7 +1,7 @@
-import './tacc-theme/addPageId.js';
-import './tacc-theme/autoScrollNav.js';
+import './tacc-theme/addIconToExternalLinks.js';
+import './tacc-theme/addPageNameToRoot.js';
+import './tacc-theme/autoScrollNavOnPageReload.js';
 import './tacc-theme/redirectNavLinks.js';
+import './tacc-theme/removeSectionClass.js';
 import './tacc-theme/setTargetForExternalLinks.mjs';
 import './tacc-theme/swapImgSvgWithRawSvg.mjs';
-import './tacc-theme/removeThemeClasses.js';
-import './tacc-theme/addIconToExternalLinks.js';

--- a/tacc_readthedocs/js/tacc-theme/addPageNameToRoot.js
+++ b/tacc_readthedocs/js/tacc-theme/addPageNameToRoot.js
@@ -1,3 +1,3 @@
-// Set page ID using global variable from readthedocs theme
+// Set page name using global variable from ReadTheDocs theme
 // https://github.com/mkdocs/mkdocs/blob/1.4.2/mkdocs/themes/readthedocs/base.html#L38
 document.body.dataset.pageName = window.mkdocs_page_input_path;

--- a/tacc_readthedocs/js/tacc-theme/autoScrollNavOnPageReload.js
+++ b/tacc_readthedocs/js/tacc-theme/autoScrollNavOnPageReload.js
@@ -1,12 +1,9 @@
-/* https://github.com/mkdocs/mkdocs/blob/1.0.4/mkdocs/themes/readthedocs/js/tacc-theme.js#L79-L105 */
-/* All changes must start and end with comments " TACC: " and " /TACC " */
+/* To make auto scroll work on page reload, not just nav within the same page */
 
-// The code below is a copy of @seanmadsen code from:
-// https://github.com/mkdocs/mkdocs/issues/803
-// This makes auto scroll work on page reload not just nav within the same page.
-//
 const $ = window.jQuery;
 
+/* https://github.com/mkdocs/mkdocs/blob/1.0.4/mkdocs/themes/readthedocs/js/theme.js#L79-L105 */
+/* All changes must start and end with comments " TACC: " and " /TACC " */
 $(function() {
   /* TACC: Do not scroll if at an anchor */
   /* FAQ: Nav already (sometimes) scrolls to link of an anchor */

--- a/tacc_readthedocs/js/tacc-theme/removeSectionClass.js
+++ b/tacc_readthedocs/js/tacc-theme/removeSectionClass.js
@@ -1,0 +1,5 @@
+/* To remove "section" class from main content inner wrapper */
+/* FAQ: The "section" class conflicts with TACC/Core-Styles o-section pattern */
+const sectionDiv = document.querySelector('[role="main"] > div.section');
+sectionDiv.classList.remove('section');
+sectionDiv.dataset.removedClass = 'section';

--- a/tacc_readthedocs/js/tacc-theme/removeThemeClasses.js
+++ b/tacc_readthedocs/js/tacc-theme/removeThemeClasses.js
@@ -1,5 +1,0 @@
-/* To remove "section" class from main content inner wrapper */
-/* FAQ: The "section" class conflicts with TACC/Core-Styles o-section pattern */
-document
-  .querySelector('[role="main"] > div.section[itemprop]')
-  .classList.remove('section');

--- a/tacc_readthedocs/js/tacc-theme/setTargetForExternalLinks.mjs
+++ b/tacc_readthedocs/js/tacc-theme/setTargetForExternalLinks.mjs
@@ -1,3 +1,3 @@
 import findLinksAndSetTargets from 'https://cdn.jsdelivr.net/gh/TACC/Core-CMS@v4.25.4/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js';
 
-findLinksAndSetTargets( document.querySelectorAll('[role="main"] a') );
+findLinksAndSetTargets( document.querySelectorAll('a') );

--- a/tacc_readthedocs/js/tacc-theme/setTargetForExternalLinks.mjs
+++ b/tacc_readthedocs/js/tacc-theme/setTargetForExternalLinks.mjs
@@ -1,3 +1,3 @@
-import findLinksAndSetTargets from 'https://cdn.jsdelivr.net/gh/TACC/Core-CMS@v3.9.2/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js';
+import findLinksAndSetTargets from 'https://cdn.jsdelivr.net/gh/TACC/Core-CMS@v4.25.4/taccsite_cms/static/site_cms/js/modules/setTargetForExternalLinks.js';
 
-findLinksAndSetTargets();
+findLinksAndSetTargets( document.querySelectorAll('[role="main"] a') );

--- a/tacc_readthedocs/main.html
+++ b/tacc_readthedocs/main.html
@@ -103,10 +103,10 @@
     </script>
     {%- endif %}
     {# /TACC #}
-    {# TACC: #}{# To remove `docutils` class from tables #}
-    {# <script src="{{ 'js/theme_extra.js'|url }}" defer></script> #}
-    {# /TACC #}
+    {# TACC: #}{# To also load TACC scripts but NOT add `.docutils` to tables #}
     <script src="{{ 'js/theme.js'|url }}" defer></script>
+    <script src="{{ 'js/tacc-theme.mjs'|url }}" type="module"></script>
+    {# /TACC #}
     {%- for path in extra_javascript %}
       {# TACC: #}{# Implicitly use `type="module"` for ES modules #}
       {% if path.endswith('.module.js') or path.endswith('.mjs') %}


### PR DESCRIPTION
### Overview

- Integrate JS into theme.
- Rename JS files.

### Related

- #4
- similar to #9

### Changes

- **deleted** `extra_javascript` (and `extra_css`) config
- **documented** `pymdownx.arithmatex` suggestion for DS-User-Guide
- **fixed** `.has-list` → `:has(ul)` should be `.has-list` → `:has(li)` (e03552f)
- **added** `data-removed-class="section"` to `div.section`
- **updated** `setTargetForExternalLinks` from v3.9.2 to v4.25.4
- **changed** `main.html` to load base ReadTheDocs theme script **and** TACC theme script

### Testing

All scripts do what they should.

### UI

Skipped.