### PR TITLE
refactor: optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,40 +2,21 @@
 
 A [TACC](https://www.tacc.utexas.edu/)-styled [MkDocs](https://www.mkdocs.org/) theme based on MkDocs' own [ReadTheDocs theme](https://www.mkdocs.org/user-guide/choosing-your-theme/#readthedocs).
 
-## Quick Start
+## How to Install
 
-<!-- Keep these steps synced with /docs/index.md -->
-
-1. Install the theme e.g.
+1. Install `mkdocs-tacc` (and optional dependencies) e.g.
 
     ```shell
-    pip install mkdocs-tacc
+    pip install "mkdocs-tacc[all]"
     ```
 
-2. Use the theme in your MkDocs project; set —
+2. In your `mkdocs.yml`:
 
-    ```yaml
-    theme:
-        name: tacc_readthedocs
-    ```
+    - Set theme name as `tacc_readthedocs`.
+    - Set [typical extensions for this theme](./docs/extensions.md#typical).
 
-    — in your `mkdocs.yml`.
-
-3. Include _at least_ the [minimum set of extensions][exts] —
-
-    ```yaml
-    markdown_extensions:
-      - toc:
-          permalink: "" # i.e. `true` but without "¶"
-          permalink_class: headerlink fa fa-link
-          permalink_title: Link to Heading
-    ```
-
-    — in your `mkdocs.yml`.
-
-[exts]: https://tacc.github.io/Core-Docs/extensions/#core-extensions
-
-Learn to [configure](https://tacc.github.io/Core-Docs/configure/), [customize](https://tacc.github.io/Core-Docs/customize/), and [extend](https://tacc.github.io/Core-Docs/extensions/) your MkDocs site.
+> [!NOTE]
+> We also offer [detailed instructions](https://tacc.github.io/Core-Docs/) instead.
 
 ## Known Clients
 
@@ -47,4 +28,4 @@ Learn to [configure](https://tacc.github.io/Core-Docs/configure/), [customize](h
 
 ## Contributing
 
-We welcome contributions. [Read "How to Contribute"](./CONTRIBUTING.md).
+We welcome contributions. Read ["How to Contribute"](./CONTRIBUTING.md).

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -8,9 +8,9 @@ _MkDocs offers a [generic guide to extending a MkDocs site](https://www.mkdocs.o
 
 ## Configuration
 
-### Minimum
+### Minimal
 
-Users of TACC MkDocs Theme should enable these extensions:
+Users of this theme should **at least** enable **these** extensions:
 
 ```yaml
 markdown_extensions:
@@ -22,23 +22,30 @@ markdown_extensions:
 
 ### Typical
 
-Standard TACC documentation websites with this theme use:
+Typical users of this theme will **both** enable **all _these_** extensions —
 
 ```yaml
 markdown_extensions:
-  - extra
-  - admonition
-  - toc:
-      permalink: "" # i.e. `true` but without "¶"
-      permalink_class: headerlink fa fa-link
-      permalink_title: Link to Heading
-  - pymdownx.blocks.admonition
-  - pymdownx.blocks.details
-  - pymdownx.blocks.html
-  - pymdownx.blocks.tab
-  - pymdownx.superfences
-  - pymdownx.inlinehilite
-  - pymdownx.saneheaders
+    - extra
+    - admonition
+    - toc:
+        permalink: "" # i.e. `true` but without "¶"
+        permalink_class: headerlink fa fa-link
+        permalink_title: Link to Heading
+    # PyMdown Extensions
+    - pymdownx.blocks.admonition
+    - pymdownx.blocks.details
+    - pymdownx.blocks.html
+    - pymdownx.blocks.tab
+    - pymdownx.superfences
+    - pymdownx.inlinehilite
+    - pymdownx.saneheaders
+```
+
+— **and** install [PyMdown Extensions](https://facelessuser.github.io/pymdown-extensions/) via optional dependency, e.g.
+
+```shell
+pip install "mkdocs-tacc[pymdown-extensions]"
 ```
 
 ## Demos

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ A [TACC](https://www.tacc.utexas.edu/)-styled [MkDocs](https://www.mkdocs.org/) 
 
     — in your `mkdocs.yml`.
 
-3. Include _at least_ the [minimum set of extensions][exts] —
+3. Include the [typical][exts-typ] or [minimal][exts-min] set of extensions — e.g.
 
     ```yaml
     markdown_extensions:
@@ -35,7 +35,8 @@ A [TACC](https://www.tacc.utexas.edu/)-styled [MkDocs](https://www.mkdocs.org/) 
 
     — in your `mkdocs.yml`.
 
-[exts]: extensions.md#core-extensions
+[exts-min]: extensions.md#minimal
+[exts-typ]: extensions.md#typical
 
 ## Configure & Customize
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -4,10 +4,9 @@
 name = "babel"
 version = "2.17.0"
 description = "Internationalization utilities"
-optional = true
+optional = false
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"i18n\""
 files = [
     {file = "babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2"},
     {file = "babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d"},
@@ -208,21 +207,6 @@ i18n = ["babel (>=2.9.0)"]
 min-versions = ["babel (==2.9.0)", "click (==7.0)", "colorama (==0.4) ; platform_system == \"Windows\"", "ghp-import (==1.0)", "importlib-metadata (==4.3) ; python_version < \"3.10\"", "jinja2 (==2.11.1)", "markdown (==3.2.1)", "markupsafe (==2.0.1)", "mergedeep (==1.3.4)", "packaging (==20.5)", "pyyaml (==5.1)", "pyyaml-env-tag (==0.1)", "typing-extensions (==3.10) ; python_version < \"3.8\"", "watchdog (==2.0)"]
 
 [[package]]
-name = "mkdocs-exclude-search"
-version = "0.6.6"
-description = "A mkdocs plugin that lets you exclude selected files or sections from the search index."
-optional = false
-python-versions = ">=3.6"
-groups = ["main"]
-files = [
-    {file = "mkdocs-exclude-search-0.6.6.tar.gz", hash = "sha256:3cdff1b9afdc1b227019cd1e124f401453235b92153d60c0e5e651a76be4f044"},
-    {file = "mkdocs_exclude_search-0.6.6-py3-none-any.whl", hash = "sha256:2b4b941d1689808db533fe4a6afba75ce76c9bab8b21d4e31efc05fd8c4e0a4f"},
-]
-
-[package.dependencies]
-mkdocs = ">=1.0.4"
-
-[[package]]
 name = "packaging"
 version = "24.2"
 description = "Core utilities for Python packages"
@@ -238,7 +222,7 @@ files = [
 name = "pymdown-extensions"
 version = "10.4"
 description = "Extension pack for Python Markdown."
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
@@ -402,9 +386,11 @@ files = [
 watchmedo = ["PyYAML (>=3.10)"]
 
 [extras]
+all = ["mkdocs", "pymdown-extensions"]
 i18n = ["mkdocs"]
+pymdown-extensions = ["pymdown-extensions"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "110def737365cb6676f25c7b227344a4128f7068e7aa66a7ae95995c29414ad0"
+content-hash = "d2c9a83252b1a5c14f96a58cc1f3ca98f7c94e666d754d2badfcf41b13755c6a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,13 +29,22 @@ license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 dependencies = [
-  "mkdocs==1.4.3",
-  "pymdown-extensions>=10.4.0",
-  "mkdocs-exclude-search>=0.6.5",
+  "mkdocs==1.4.3"
 ]
 
 [project.optional-dependencies]
 i18n = ["mkdocs[i18n]==1.4.3"]
+pymdown-extensions = ["pymdown-extensions>=10.4.0"]
+all = ["mkdocs[i18n]==1.4.3", "pymdown-extensions>=10.4.0"]
+
+# FAQ: for Poetry 1.x compatibility (Poetry 2+ should use above format)
+[tool.poetry.dependencies]
+mkdocs = "==1.4.3"
+pymdown-extensions = {version = ">=10.4.0", optional = true}
+[tool.poetry.extras]
+i18n = [] # empty cuz Poetry 1.x cannot handle nested extra; use pip for `i18n`
+pymdown-extensions = ["pymdown-extensions"]
+all = ["pymdown-extensions"] # for consistency with `all` offered for PIP users
 
 [project.urls]
 # homepage = "https://docs.tacc.utexas.edu"


### PR DESCRIPTION
### Overview

- Makes `pymdown-extensions` optional.
- Removes `mkdocs-exclude-search`.
- Improves installation documentation.

### Related

- https://github.com/TACC/TACC-Docs/pull/95

### Changes

- **changed** dependencies
- **removed** `mkdocs-exclude-search`
- **added** dependency group `all`
- **added** Poetry 1.x compatibility
- **renamed** "Minimum" to "Minimal" for clarity
- **improved** install instructions
- **updated** doc links

### Testing

1. Verify installation with: `pip install mkdocs-tacc`, `pip install "mkdocs-tacc[pymdown-extensions]"`, and `pip install "mkdocs-tacc[all]"`.
2. Confirm documentation accuracy.
3. Verify functionality with new dependency structure.

### UI

Skipped.
